### PR TITLE
Removed options for specifying custom modules

### DIFF
--- a/src/llm-evals/config-tests.yaml
+++ b/src/llm-evals/config-tests.yaml
@@ -1,9 +1,7 @@
 
 
 # paths are relative to the root of the repo
-function_metrics_path: '../../configuration/function_metrics.py'
 rubric_metrics_path: '../../configuration/rubric_metrics.yaml'
-completion_functions: '../../configuration/completion_functions.py'
 evals_path: tests/evals.yaml
 env_file: .env #in same location as main.py
 logs_path: tests/logs/

--- a/src/llm-evals/config.yaml
+++ b/src/llm-evals/config.yaml
@@ -1,9 +1,7 @@
 
 
 # paths are relative to the root of the repo
-function_metrics_path: '../../configuration/function_metrics.py'
 rubric_metrics_path: '../../configuration/rubric_metrics.yaml'
-completion_functions: '../../configuration/completion_functions.py'
 evals_path: '../../configuration/evals.yaml'
 env_file: '.env' #in same location as main.py
 logs_path: '../../logs/'


### PR DESCRIPTION
 Removed options for specifying modules for function_metrics and completion_functions to match code functionality where these paths were not used (and pre-set defaults are used instead).