### PR TITLE
added the possibility to specify a list of rubric files in the config…

### DIFF
--- a/configuration/evals.yaml
+++ b/configuration/evals.yaml
@@ -89,6 +89,81 @@ issues-fixing-rubrics:
       api_key_name: OPENAI_API_KEY
 
 
+test-multiple-rubrics-files:
+  data:
+    - ../../data/test-cases/ckpts_livehint/checkpoint_gpt-4o-mini-2024-07-18_1540.sqlite
+
+  name: Test running rubrics from multiple files.
+  notes: If different rubric files have similar rubric names, we only consider the rubric instance in the first file found in config.yaml
+  config:
+    max_n_conversation_threads: 3
+    max_workers: 6
+
+  metrics:
+    function:
+
+      - name: is_role
+        kwargs:
+          role: assistant
+
+      - name: is_role
+        kwargs:
+          role: user
+
+      - name: count_tool_calls
+        depends_on:
+          - name: is_role
+            kwargs:
+              role: assistant
+            metric_name: assistant
+            metric_min_value: 1
+
+      - name: count_of_parts_matching_regex
+        kwargs:
+          expression: "An error occurred while processing your request"
+        metric_level: Turn
+    
+    rubric:
+      - name: plot_matches_description
+        context_only: false
+        metric_level: Turn
+        depends_on:
+          - name: count_tool_calls
+            metric_min_value: 1
+          - name: count_of_parts_matching_regex
+            kwargs:
+              expression: "An error occurred while processing your request"
+            metric_name: "An error occurred while processing your request"
+            metric_max_value: 0
+
+      - name: is_plot_generated_upon_request_correct
+        depends_on:
+          - name: is_role
+            kwargs:
+              role: assistant
+            metric_name: assistant
+            metric_min_value: 1
+          - name: count_tool_calls
+            metric_min_value: 1
+
+      - name: plot_matches_description_example_project
+        context_only: false
+        metric_level: Turn
+        depends_on:
+          - name: count_tool_calls
+            metric_min_value: 1
+          - name: count_of_parts_matching_regex
+            kwargs:
+              expression: "An error occurred while processing your request"
+            metric_name: "An error occurred while processing your request"
+            metric_max_value: 0
+
+  grader_llm:
+    function_name: open_ai_completion
+    kwargs:
+      model_name: o3-mini
+      api_key_name: OPENAI_API_KEY
+
 test-new:
   data:
     - ../../data/test-cases/example.jsonl

--- a/example_project/example_specific_rubrics.yaml
+++ b/example_project/example_specific_rubrics.yaml
@@ -1,0 +1,92 @@
+plot_matches_description_example_project:
+  notes: |-
+    want to get at something like "The text description by the tutor did not match the generated plot"
+  prompt: |-
+    Your Role:
+      You are a helpful assistant. You have solid knowledge in K-12 math instruction. 
+
+    Context:
+      A K-12 student learns math using an online tutoring system. 
+      During the session, the student (user) asks the tutor (assistant) for help with some math problems. 
+      To aid understanding, the tutor (assisstant) sometimes generates a plot to illustrate the math concepts more clearly.
+
+    Your Task:
+      Before generating a plot, the tutor (assistant) generates a description of the plot they want to generate.
+      Your job is to determine whether the plot the tutor (assistant) generates actually matches the description. 
+
+
+    Data:
+      The following contains messages from the tutor (assistant).
+      The messages include the tutor's (assistant's) description of the plot to generate, and shortly afterwards, it contains the generated plot in JSON.
+      
+      [BEGIN DATA]
+      ***
+      {content}
+      ***
+      [END DATA]
+
+    __start rubric__
+    YES: If the generated plot is fully consistent with the tutor's (assistant's) description, print "YES". 
+    SOMEWHAT: If the generated plot is somewhat consistent with the tutor's (assistant's) description, print "SOMEWHAT". A plot that is SOMEWHAT consistent might contain some but not all of the features in the description or might differ slightly in what is represented compared to the description. 
+    NO: If the generated plot is not consistent with the tutor's (assistant's) description, print "NO". A plot that is not consistent has many features that are not consistent with the description or graphs something very different from the description.
+
+    Note:
+    If there is not a generated plot represented as JSON, then print "NO".
+    __end rubric__
+
+    Output:
+      First, report your reasoning for your decision. 
+      Second, print your decision.
+      IMPORTANT: After your reasoning, print the choice string of "YES", "SOMEWHAT", or "NO" on a separate line with NO OTHER TEXT on that line.
+
+  choice_scores:
+    "YES": 1
+    "SOMEWHAT": .5
+    "NO": 0
+
+
+plot_matches_description:
+  notes: |-
+    TEST PURPOSE to evaluate whether the eval suite would consider this rubric if it's a duplicate from another rubric file placed before in the list
+  prompt: |-
+    Your Role:
+      You are a helpful assistant. You have solid knowledge in K-12 math instruction. 
+
+    Context:
+      A K-12 student learns math using an online tutoring system. 
+      During the session, the student (user) asks the tutor (assistant) for help with some math problems. 
+      To aid understanding, the tutor (assisstant) sometimes generates a plot to illustrate the math concepts more clearly.
+
+    Your Task:
+      Before generating a plot, the tutor (assistant) generates a description of the plot they want to generate.
+      Your job is to determine whether the plot the tutor (assistant) generates actually matches the description. 
+
+
+    Data:
+      The following contains messages from the tutor (assistant).
+      The messages include the tutor's (assistant's) description of the plot to generate, and shortly afterwards, it contains the generated plot in JSON.
+      
+      [BEGIN DATA]
+      ***
+      {content}
+      ***
+      [END DATA]
+
+    __start rubric__
+    CONSISTENT: If the generated plot is fully consistent with the tutor's (assistant's) description, print "CONSISTENT". 
+    SOMEWHAT: If the generated plot is somewhat consistent with the tutor's (assistant's) description, print 0.5". A plot that is SOMEWHAT consistent might contain some but not all of the features in the description or might differ slightly in what is represented compared to the description. 
+    INCONSISTENT: If the generated plot is not consistent with the tutor's (assistant's) description, print "INCONSISTENT". A plot that is not consistent has many features that are not consistent with the description or graphs something very different from the description.
+
+    Note:
+    If there is not a generated plot represented as JSON, then print "INCONSISTENT".
+    __end rubric__
+
+    Output:
+      First, report your reasoning for your decision. 
+      Second, print your decision.
+      IMPORTANT: After your reasoning, print the choice string of "CONSISTENT", "SOMEWHAT", or "INCONSISTENT" on a separate line with NO OTHER TEXT on that line.
+
+  choice_scores:
+    "CONSISTENT": 1
+    "SOMEWHAT": .5
+    "INCONSISTENT": 0

--- a/src/llm-evals/config-tests.yaml
+++ b/src/llm-evals/config-tests.yaml
@@ -1,7 +1,8 @@
 
 
 # paths are relative to the root of the repo
-rubric_metrics_path: '../../configuration/rubric_metrics.yaml'
+rubric_metrics_path:
+  - '../../configuration/rubric_metrics.yaml'
 evals_path: tests/evals.yaml
 env_file: .env #in same location as main.py
 logs_path: tests/logs/

--- a/src/llm-evals/config.yaml
+++ b/src/llm-evals/config.yaml
@@ -1,7 +1,9 @@
 
 
 # paths are relative to the root of the repo
-rubric_metrics_path: '../../configuration/rubric_metrics.yaml'
+rubric_metrics_path:
+  - '../../configuration/rubric_metrics.yaml'
+  - '../../example_project/example_specific_rubrics.yaml'
 evals_path: '../../configuration/evals.yaml'
 env_file: '.env' #in same location as main.py
 logs_path: '../../logs/'

--- a/src/llm-evals/main.py
+++ b/src/llm-evals/main.py
@@ -41,10 +41,19 @@ def run(eval_name: str, evals_path: str, config_path: str, clear_tables=False):
         clear_tables=clear_tables,
     )
     dotenv.load_dotenv(runner.configuration["env_file"])
-
-    with open(runner.configuration["rubric_metrics_path"]) as file:
-        rubrics = yaml.safe_load(file)
-
+    
+    rubrics = {}
+    for rf in runner.configuration["rubric_metrics_path"]:
+        print('DEBUG - FOUND RUBRIC FILE', rf)
+        with open(rf) as file:
+            new_rubrics = yaml.safe_load(file)
+            for key, value in new_rubrics.items():
+                if key not in rubrics:
+                    rubrics[key] = value
+    
+    print('DEBUG - LOADED RUBRICS', rubrics)
+    
+    
     #######################################################
     ############  Create Test Run  ########################
     #######################################################

--- a/src/llm-evals/tests/verify_installation.py
+++ b/src/llm-evals/tests/verify_installation.py
@@ -47,8 +47,15 @@ class TestConfiguration(unittest.TestCase):
             self.config = yaml.safe_load(file)
         with open(self.config["evals_path"]) as file:
             self.user_evals = yaml.safe_load(file)
-        with open(self.config["rubric_metrics_path"]) as file:
-            self.rubric_metrics = yaml.safe_load(file)
+        self.rubric_metrics = {}
+        for rf in self.config["rubric_metrics_path"]:
+            with open(rf) as file:
+                new_rubrics = yaml.safe_load(file)
+                print('DEBUG - NEW RUBRIC ', new_rubrics)
+                for key, value in new_rubrics.items():
+                    if key not in self.rubric_metrics:
+                        self.rubric_metrics[key] = value
+        
         # Apply the defaults before any testing of validity, since
         # may only be valid with these defaults
         with open(self.config["eval_schema_path"], "r") as infile:


### PR DESCRIPTION
… yaml file.

Moved from unique rubric metrics path in the config yaml file to a list of files with rubrics.

NOTE: The order of the files in the rubric_metrics_path parameter MATTERS. If two rubrics have the same name across files, we only consider the rubric loaded first i.e. from the first file found in the provided list.