### PR TITLE
MetricItem default depends_on changed to empty list

### DIFF
--- a/src/flexeval/schema/eval_schema.py
+++ b/src/flexeval/schema/eval_schema.py
@@ -61,7 +61,7 @@ class MetricItem(BaseModel):
         description="The function to call or name of rubric to use to compute this metric.",
     )
     depends_on: Optional[List[DependsOnItem]] = Field(
-        default_factory=list,
+        [],
         description="List of dependencies that must be satisfied for this metric to be computed.",
     )
     # TODO why is metric_level optional? Should likely make it required


### PR DESCRIPTION
Proposed fix for #53.

When running a basic evaluation defining a Function or Rubric metric with the MetricItem base class, we can define a depends_on parameter that specifies the list of dependencies satisfied for the metric to be run.
The dependency_graph's get_parent_metrics function expects the metric's depends_on field to return an iterable and never None:

line 131
```for requirement in child.get("depends_on", []):```

which triggered #53 error when the field was None by default.

This fix proposes to change the default value of the depends_on attribute to empty list instead of None in the class definition.