### PR TITLE
Auto-merge non-major Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
   schedule:
     interval: "weekly"
   target-branch: "main"
+  groups:
+    # Batch all non-major updates into a single PR; majors stay separate
+    # so they can be reviewed individually (and skipped by auto-merge).
+    python-dependencies:
+      patterns: ["*"]
+      update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# Automatically enable auto-merge on Dependabot PRs. GitHub holds the merge
+# until the "Run validation" required status check (see the "Merging to main"
+# ruleset) passes, so tests still gate every merge. Major version bumps are
+# skipped so a human reviews them.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge (skip majors)
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- **Group** minor/patch dependency updates into a single weekly Dependabot PR (`.github/dependabot.yml`). Major bumps remain separate PRs.
- **Auto-merge** Dependabot PRs once checks pass (`.github/workflows/dependabot-auto-merge.yml`), skipping majors so they get a human review.

## Why

Manually merging independent Dependabot PRs is toil when the GH Actions tests are the only gate.

## Safety

The "Merging to main" ruleset was updated to require the `Run validation` status check. Auto-merge holds the merge until that check is green, so tests still gate every merge — including this automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)